### PR TITLE
state 中无 offset 的处理

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -389,7 +389,7 @@ export default class extends Component {
       // Setting the offset to the same thing will not do anything,
       // so we increment it by 1 then immediately set it to what it should be,
       // after render.
-      if (offset[dir] === this.internals.offset[dir]) {
+      if (offset[dir] === (this.internals && this.internals.offset[dir])) {
         newState.offset = { x: 0, y: 0 }
         newState.offset[dir] = offset[dir] + 1
         this.setState(newState, () => {


### PR DESCRIPTION
state 中无 offset 的处理 当 state 中没有 offset 的时候， 会提示报错， “cannot read property 'x' of undefined”, 经过排查之后， 发现是在取 state 的 offset 的时候出现问题，经验证，处理之后， 不会有异常

### Is it a bugfix ?

may be a bug
